### PR TITLE
Remove self-package from docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,7 +8,6 @@ OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-WildlandFire = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
 [compat]
 DynamicQuantities = "1"


### PR DESCRIPTION
## Summary

- Remove `WildlandFire` from the `[deps]` section of `docs/Project.toml`
- The docs CI already runs `Pkg.develop(PackageSpec(path=pwd()))` which adds the local package automatically, making the explicit dependency redundant
- This prevents CompatHelper from creating unnecessary PRs to bump the self-package version in docs whenever a new release is tagged

## Test plan

- [ ] Verify docs CI still builds successfully without the explicit self-dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)