### PR TITLE
Refactor LevelSetFireSpread to accept DomainInfo

### DIFF
--- a/docs/src/level_set_fire_spread.md
+++ b/docs/src/level_set_fire_spread.md
@@ -87,12 +87,16 @@ WENO spatial discretization and third-order Runge-Kutta temporal integration.
 
 ```@example levelset
 using DataFrames, ModelingToolkit, Symbolics, DynamicQuantities
-using WildlandFire
+using ModelingToolkit: t
+using WildlandFire, EarthSciMLBase, DomainSets
 
-sys = LevelSetFireSpread(
-    x_domain = (0.0, 100.0),
-    y_domain = (0.0, 100.0),
-    t_domain = (0.0, 10.0),
+@parameters x [unit = u"m"]
+@parameters y [unit = u"m"]
+domain = DomainInfo(
+    constIC(0.0, t ∈ Interval(0.0, 10.0)),
+    constBC(0.0, x ∈ Interval(0.0, 100.0), y ∈ Interval(0.0, 100.0)),
+)
+sys = LevelSetFireSpread(domain;
     initial_condition = (x, y) -> sqrt((x - 50.0)^2 + (y - 50.0)^2) - 10.0,
 )
 
@@ -298,7 +302,7 @@ This is the fundamental analytical solution for the level-set equation
 (Mandel et al. 2011, Sect. 3.4).
 
 ```@example levelset
-using MethodOfLines, DomainSets, OrdinaryDiffEqDefault, Plots
+using MethodOfLines, OrdinaryDiffEqDefault, Plots
 
 r0 = 10.0       # initial radius (m)
 S_val = 1.0      # spread rate (m/s)
@@ -306,10 +310,11 @@ domain_size = 100.0
 center = domain_size / 2.0
 t_end = 10.0
 
-sys = LevelSetFireSpread(
-    x_domain = (0.0, domain_size),
-    y_domain = (0.0, domain_size),
-    t_domain = (0.0, t_end),
+domain_circ = DomainInfo(
+    constIC(0.0, t ∈ Interval(0.0, t_end)),
+    constBC(0.0, x ∈ Interval(0.0, domain_size), y ∈ Interval(0.0, domain_size)),
+)
+sys = LevelSetFireSpread(domain_circ;
     initial_condition = (x, y) -> sqrt((x - center)^2 + (y - center)^2) - r0,
     spread_rate = S_val,
 )

--- a/src/level_set_fire_spread.jl
+++ b/src/level_set_fire_spread.jl
@@ -1,7 +1,7 @@
 """
-    LevelSetFireSpread(; name=:LevelSetFireSpread, x_domain, y_domain,
-                         t_domain, initial_condition, boundary_conditions=nothing,
-                         spread_rate=1.0)
+    LevelSetFireSpread(domain::DomainInfo; name=:LevelSetFireSpread,
+                       initial_condition, boundary_conditions=nothing,
+                       spread_rate=1.0)
 
 Create a level-set fire front propagation PDE system.
 
@@ -30,10 +30,9 @@ accuracy, consider the full Muñoz-Esparza et al. (2018) algorithm which include
 - Level-set reinitialization for maintaining signed distance property
 
 # Arguments
+- `domain`: A `DomainInfo` object specifying the spatial (x, y) and temporal (t) domains.
+  Must have exactly 2 spatial dimensions.
 - `name`: System name (default `:LevelSetFireSpread`)
-- `x_domain`: Tuple (x_min, x_max) defining the x-extent of the domain (m)
-- `y_domain`: Tuple (y_min, y_max) defining the y-extent of the domain (m)
-- `t_domain`: Tuple (t_min, t_max) defining the time interval (s)
 - `initial_condition`: Function `(x, y) -> ψ₀` giving the initial level-set field.
   Negative values indicate initial fire region, positive values indicate unburned fuel.
 - `boundary_conditions`: Optional vector of boundary condition equations. If not provided,
@@ -56,20 +55,23 @@ doi:10.5194/gmd-4-591-2011
 # Example
 
 ```julia
-using WildlandFire, MethodOfLines, DomainSets, OrdinaryDiffEqDefault
+using WildlandFire, EarthSciMLBase, ModelingToolkit, DynamicQuantities
+using ModelingToolkit: t
+using MethodOfLines, DomainSets, OrdinaryDiffEqDefault
 
 # Domain: 500m x 500m, 60 seconds
-x_domain = (0.0, 500.0)
-y_domain = (0.0, 500.0)
-t_domain = (0.0, 60.0)
+@parameters x [unit = u"m"]
+@parameters y [unit = u"m"]
+domain = DomainInfo(
+    constIC(0.0, t ∈ Interval(0.0, 60.0)),
+    constBC(0.0, x ∈ Interval(0.0, 500.0), y ∈ Interval(0.0, 500.0)),
+)
 
 # Circular ignition at center (radius 10m)
 initial_condition(x, y) = sqrt((x - 250.0)^2 + (y - 250.0)^2) - 10.0
 
 # Create PDE system
-sys = LevelSetFireSpread(;
-    x_domain, y_domain, t_domain, initial_condition,
-)
+sys = LevelSetFireSpread(domain; initial_condition)
 
 # Discretize and solve
 dx = 5.0
@@ -78,18 +80,25 @@ prob = MethodOfLines.discretize(sys, discretization; checks=false)
 sol = solve(prob)
 ```
 """
-function LevelSetFireSpread(;
+function LevelSetFireSpread(
+        domain::DomainInfo;
         name = :LevelSetFireSpread,
-        x_domain::Tuple{Float64, Float64},
-        y_domain::Tuple{Float64, Float64},
-        t_domain::Tuple{Float64, Float64},
         initial_condition,
         boundary_conditions = nothing,
         spread_rate = 1.0
     )
 
-    @parameters x [description = "Horizontal coordinate x", unit = u"m"]
-    @parameters y [description = "Horizontal coordinate y", unit = u"m"]
+    # Extract domain information
+    t_domain = get_tspan(domain)
+    spatial_eps = EarthSciMLBase.endpoints(domain)
+    @assert length(spatial_eps) == 2 "LevelSetFireSpread requires exactly 2 spatial dimensions, got $(length(spatial_eps))"
+    x_domain = spatial_eps[1]
+    y_domain = spatial_eps[2]
+
+    # Get spatial variables from domain
+    spatial_vars = EarthSciMLBase.pvars(domain)
+    x = spatial_vars[1]
+    y = spatial_vars[2]
 
     # Fire spread rate with default value
     @parameters S = spread_rate [description = "Fire spread rate", unit = u"m/s"]
@@ -119,11 +128,7 @@ function LevelSetFireSpread(;
         ψ_ref = 1.0, [description = "Reference length for initial condition", unit = u"m"]
     end
 
-    domains = [
-        t ∈ Interval(t_domain[1], t_domain[2]),
-        x ∈ Interval(x_domain[1], x_domain[2]),
-        y ∈ Interval(y_domain[1], y_domain[2]),
-    ]
+    pde_domains = EarthSciMLBase.domains(domain)
 
     # Initial condition
     ic = ψ(t_domain[1], x, y) ~ initial_condition(x, y) * ψ_ref
@@ -142,7 +147,7 @@ function LevelSetFireSpread(;
     end
 
     return PDESystem(
-        eq, bcs, domains, [t, x, y], [ψ(t, x, y)],
+        eq, bcs, pde_domains, [t, x, y], [ψ(t, x, y)],
         [S, ψ_ref]; name = name
     )
 end

--- a/test/test_level_set_fire_spread.jl
+++ b/test/test_level_set_fire_spread.jl
@@ -2,17 +2,23 @@
     using Test
     using ModelingToolkit
     using ModelingToolkit: t, D
+    using DynamicQuantities
     using WildlandFire
+    using EarthSciMLBase
     using MethodOfLines
     using OrdinaryDiffEqDefault
     using DomainSets
 end
 
 @testitem "LevelSetFireSpread - Structural Verification" setup = [LevelSetSetup] tags = [:levelset] begin
+    @parameters x [unit = u"m"]
+    @parameters y [unit = u"m"]
+    domain = DomainInfo(
+        constIC(0.0, t ∈ Interval(0.0, 10.0)),
+        constBC(0.0, x ∈ Interval(0.0, 100.0), y ∈ Interval(0.0, 100.0)),
+    )
     sys = LevelSetFireSpread(
-        x_domain = (0.0, 100.0),
-        y_domain = (0.0, 100.0),
-        t_domain = (0.0, 10.0),
+        domain;
         initial_condition = (x, y) -> sqrt((x - 50.0)^2 + (y - 50.0)^2) - 10.0,
         spread_rate = 1.0,
     )
@@ -40,10 +46,14 @@ end
     center = domain_size / 2.0
     t_end = 5.0
 
+    @parameters x [unit = u"m"]
+    @parameters y [unit = u"m"]
+    domain = DomainInfo(
+        constIC(0.0, t ∈ Interval(0.0, t_end)),
+        constBC(0.0, x ∈ Interval(0.0, domain_size), y ∈ Interval(0.0, domain_size)),
+    )
     sys = LevelSetFireSpread(
-        x_domain = (0.0, domain_size),
-        y_domain = (0.0, domain_size),
-        t_domain = (0.0, t_end),
+        domain;
         initial_condition = (x, y) -> sqrt((x - center)^2 + (y - center)^2) - r0,
         spread_rate = S_val,
     )
@@ -86,8 +96,6 @@ end
 end
 
 @testitem "LevelSetFireSpread - Custom Boundary Conditions" setup = [LevelSetSetup] tags = [:levelset] begin
-    using DynamicQuantities
-
     # Test that custom boundary conditions can be provided
     @parameters x [description = "x", unit = u"m"]
     @parameters y [description = "y", unit = u"m"]
@@ -105,10 +113,12 @@ end
         ψ(t, x, 100.0) ~ ψ_bc,
     ]
 
+    domain = DomainInfo(
+        constIC(0.0, t ∈ Interval(0.0, 5.0)),
+        constBC(0.0, x ∈ Interval(0.0, 100.0), y ∈ Interval(0.0, 100.0)),
+    )
     sys = LevelSetFireSpread(
-        x_domain = (0.0, 100.0),
-        y_domain = (0.0, 100.0),
-        t_domain = (0.0, 5.0),
+        domain;
         initial_condition = (x, y) -> sqrt((x - 50.0)^2 + (y - 50.0)^2) - 10.0,
         boundary_conditions = custom_bcs,
     )


### PR DESCRIPTION
## Summary
- Replace `x_domain`, `y_domain`, `t_domain` keyword arguments with a single required `domain::DomainInfo` positional argument in `LevelSetFireSpread`
- Extract domain bounds and spatial variables from `DomainInfo` using `get_tspan`, `EarthSciMLBase.endpoints`, and `EarthSciMLBase.pvars`
- Update all tests and documentation examples to construct a `DomainInfo` and pass it to `LevelSetFireSpread`

## Test plan
- [x] All 260 existing tests pass
- [x] Structural, circular spread, and custom boundary condition tests updated and passing
- [x] Documentation examples updated to use `DomainInfo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)