### PR TITLE
Support non-meter domains (e.g., lat-lon) in LevelSetFireSpread

### DIFF
--- a/src/level_set_fire_spread.jl
+++ b/src/level_set_fire_spread.jl
@@ -91,11 +91,11 @@ function LevelSetFireSpread(
     # Extract domain information
     t_domain = get_tspan(domain)
     spatial_eps = EarthSciMLBase.endpoints(domain)
-    @assert length(spatial_eps) == 2 "LevelSetFireSpread requires exactly 2 spatial dimensions, got $(length(spatial_eps))"
+    @assert length(spatial_eps) >= 2 "LevelSetFireSpread requires at least 2 spatial dimensions, got $(length(spatial_eps))"
     x_domain = spatial_eps[1]
     y_domain = spatial_eps[2]
 
-    # Get spatial variables from domain
+    # Get spatial variables from domain (use only the first 2 for the 2D fire PDE)
     spatial_vars = EarthSciMLBase.pvars(domain)
     x = spatial_vars[1]
     y = spatial_vars[2]
@@ -106,14 +106,33 @@ function LevelSetFireSpread(
     # Level-set function
     @variables ψ(..) [description = "Level-set function (fire front at ψ=0)", unit = u"m"]
 
-    # Spatial derivative operators
+    # Spatial derivative operators with coordinate transforms
+    # For meter domains, transforms are identity (1); for lat-lon, they convert
+    # d/d(rad) to d/d(meter) so the gradient is in physical space.
+    δs = EarthSciMLBase.partialderivatives(domain)
+    transforms = EarthSciMLBase.partialderivative_transforms(domain)
     Dx = Differential(x)
     Dy = Differential(y)
 
+    # Collect symbolic constants/parameters introduced by coordinate transforms
+    # (e.g., lat2meters, lon2m) so they can be included in the PDESystem.
+    ivs_set = Set(Symbolics.unwrap.([t, x, y]))
+    transform_params_set = Set{Any}()
+    transform_params = Num[]
+    for tf in transforms
+        tf isa Integer && continue  # Skip identity transforms (literal 1)
+        for v in Symbolics.get_variables(tf)
+            uv = Symbolics.unwrap(v)
+            if uv ∉ ivs_set && uv ∉ transform_params_set
+                push!(transform_params_set, uv)
+                push!(transform_params, v)
+            end
+        end
+    end
+
     # Gradient components — Eq. 6, Mandel et al. (2011)
-    # ψ has units m, x and y have units m, so Dx(ψ) and Dy(ψ) are dimensionless
-    ψ_x = Dx(ψ(t, x, y))
-    ψ_y = Dy(ψ(t, x, y))
+    ψ_x = δs[1](ψ(t, x, y))
+    ψ_y = δs[2](ψ(t, x, y))
 
     # Level-set equation — Eq. 9, Mandel et al. (2011)
     # ∂ψ/∂t + S‖∇ψ‖ = 0
@@ -148,7 +167,7 @@ function LevelSetFireSpread(
 
     return PDESystem(
         eq, bcs, pde_domains, [t, x, y], [ψ(t, x, y)],
-        [S, ψ_ref]; name = name,
+        [S, ψ_ref, transform_params...]; name = name,
         metadata = Dict(EarthSciMLBase.CoupleType => LevelSetCoupler)
     )
 end

--- a/test/test_level_set_fire_spread.jl
+++ b/test/test_level_set_fire_spread.jl
@@ -129,6 +129,58 @@ end
     @test length(sys.bcs) == 5  # 1 IC + 4 custom BCs
 end
 
+@testitem "LevelSetFireSpread - Lat-Lon Domain" setup = [LevelSetSetup] tags = [:levelset] begin
+    # Test that LevelSetFireSpread works with lat-lon coordinates and coordinate transforms
+    @parameters lon [unit = u"rad"]
+    @parameters lat [unit = u"rad"]
+    t_end = 300.0  # 5 minutes
+    S_val = 5.0    # 5 m/s spread rate
+    domain = DomainInfo(
+        EarthSciMLBase.partialderivatives_δxyδlonlat,
+        constIC(0.0, t ∈ Interval(0.0, t_end)),
+        constBC(
+            0.0,
+            lon ∈ Interval(-0.01, 0.01),
+            lat ∈ Interval(-0.01, 0.01)
+        ),
+    )
+
+    # Initial condition: circular fire near origin
+    # Use approximate Earth radius to convert radians to meters for distance calc
+    R_earth = 6.371e6
+    initial_condition(lon, lat) = sqrt(
+        (lon * R_earth)^2 + (lat * R_earth)^2
+    ) - 100.0  # 100m radius ignition
+
+    sys = LevelSetFireSpread(domain; initial_condition, spread_rate = S_val)
+
+    @test sys isa PDESystem
+    @test length(equations(sys)) == 1
+    @test length(sys.ivs) == 3  # t, lon, lat
+
+    # Verify it can be discretized and solved
+    # dlon = 0.001 rad ≈ 6.4 km grid spacing near the equator (coarse)
+    dlon = 0.001
+    discretization = MOLFiniteDifference(
+        [sys.ivs[2] => dlon, sys.ivs[3] => dlon], sys.ivs[1];
+        advection_scheme = WENOScheme()
+    )
+    prob = MethodOfLines.discretize(sys, discretization; checks = false)
+    sol = solve(prob; saveat = t_end)
+    @test sol.retcode == SciMLBase.ReturnCode.Success
+
+    # The grid is coarse (~6.4 km cells) so the fire front won't cross cell
+    # boundaries in 300s at 5 m/s (~1.5 km advance). Instead, verify that
+    # level-set values decreased (fire front is approaching unburned cells).
+    psi = sol[sys.dvs[1]]
+    mid = div(size(psi, 2), 2) + 1
+    # Adjacent cell to fire center: ψ should decrease as fire approaches
+    @test psi[end, mid + 1, mid] < psi[1, mid + 1, mid]
+    # Expected decrease ≈ S * t_end = 5 * 300 = 1500m
+    decrease = psi[1, mid + 1, mid] - psi[end, mid + 1, mid]
+    @test isapprox(decrease, S_val * t_end, rtol = 0.15)
+end
+
 @testitem "FuelConsumption - Structural Verification" setup = [LevelSetSetup] tags = [:levelset] begin
     fc = FuelConsumption()
     @test fc !== nothing


### PR DESCRIPTION
## Summary

- Use `EarthSciMLBase.partialderivatives(domain)` to apply coordinate transforms to spatial derivatives in the level-set equation, so the gradient is computed in physical space (meters) regardless of the domain's coordinate system
- Collect symbolic constants from coordinate transforms (e.g., `lat2meters`, `lon2m`) and include them in the PDESystem parameter list
- Add a test with a lat-lon domain that verifies discretization, solving, and correct fire spread rate

## Test plan

- [x] All 266 existing tests pass (no regressions)
- [x] New lat-lon domain test verifies structural correctness, successful solve, and correct spread rate
- [x] Meter-domain behavior unchanged (transforms are identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)