### PR TITLE
Fix wind factor U_ref unit conversion in Rothermel model

### DIFF
--- a/src/rothermel.jl
+++ b/src/rothermel.jl
@@ -70,9 +70,13 @@ sol = solve(prob)
 @component function RothermelFireSpread(; name = :RothermelFireSpread)
     # Reference values for non-dimensionalization of quantities raised to non-integer powers
     # Following CLAUDE.md guidance: divide by reference, raise to power, multiply back
+    #
+    # U_ref converts m/s to ft/min for the wind factor equation, whose empirical
+    # coefficients were calibrated with U in ft/min (Rothermel 1972).
+    # 1 ft/min = 0.3048/60 m/s ≈ 0.00508 m/s.
     @constants begin
         σ_ref = 1.0, [description = "Reference SAV ratio for non-dimensionalization", unit = u"1/m"]
-        U_ref = 1.0, [description = "Reference wind speed for non-dimensionalization", unit = u"m/s"]
+        U_ref = 0.3048 / 60, [description = "Reference wind speed (1 ft/min in m/s)", unit = u"m/s"]
         IB_ref = 1.0, [description = "Reference fireline intensity for non-dimensionalization", unit = u"W/m"]
         one = 1.0, [description = "Dimensionless one for unit balancing", unit = u"1"]
     end
@@ -403,9 +407,9 @@ CO: U.S. Department of Agriculture, Forest Service, Rocky Mountain Research Stat
         UE(t), [description = "Effective midflame wind speed", unit = u"m/s"]
     end
 
-    # Reference for non-dimensionalization
+    # Reference for non-dimensionalization (must match U_ref in RothermelFireSpread)
     @constants begin
-        UE_ref = 1.0, [description = "Reference wind speed for unit conversion", unit = u"m/s"]
+        UE_ref = 0.3048 / 60, [description = "Reference wind speed (1 ft/min in m/s)", unit = u"m/s"]
     end
 
     eqs = [

--- a/test/test_rothermel.jl
+++ b/test/test_rothermel.jl
@@ -563,8 +563,10 @@ end
     UE = sol[compiled_sys.UE]
     @test UE > 0
 
-    # Test the inverse relationship: UE = [(φE * β_ratio^E) / C]^(1/B)
-    UE_expected = (φE * 0.5^0.5 / 7.47)^(1 / 0.15)
+    # Test the inverse relationship: UE = UE_ref * [(φE * β_ratio^E) / C]^(1/B)
+    # UE_ref = 0.3048/60 m/s (1 ft/min), matching U_ref in RothermelFireSpread
+    UE_ref = 0.3048 / 60
+    UE_expected = UE_ref * (φE * 0.5^0.5 / 7.47)^(1 / 0.15)
     @test UE ≈ UE_expected rtol = 1.0e-6
 
     # Test with no slope factor


### PR DESCRIPTION
## Summary

- Fix `U_ref` from `1.0 m/s` to `0.3048/60 m/s` (1 ft/min) in `RothermelFireSpread`, so the wind factor equation correctly converts m/s to the ft/min scale expected by the empirical coefficients
- Apply same fix to `UE_ref` in `EffectiveMidflameWindSpeed`
- Update the corresponding test expectation

## Problem

The wind factor equation `φw = C·(U/U_ref)^B·β_ratio^(-E)` had `U_ref=1.0 m/s`, but the empirical exponent `B` was calibrated with `U` in ft/min (Rothermel 1972, Andrews 2018). This caused `(U/U_ref)^B` to be ~10,000x too small for typical wind speeds, effectively making `φw ≈ 0` regardless of wind conditions.

For example, with Fuel Model 1 (short grass) and a 5 mi/h wind:
- **Before fix:** `φw = 0.0004` (wind has no effect)
- **After fix:** `φw = 21.4` (correct wind enhancement)

## Test plan

- [x] All 62 existing Rothermel tests pass
- [ ] Full test suite passes
- [ ] Verified against US customary unit calculations (FM1, 5 mi/h → φw ≈ 21.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)