### PR TITLE
Fix FuelModelLookup for non-burnable LANDFIRE codes

### DIFF
--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -39,6 +39,9 @@ end
 
 # ---- Fuel model lookup functions (registered for symbolic use) ---------------
 
+# LANDFIRE non-burnable fuel model codes (urban, snow/ice, agriculture, water, barren).
+const _NONBURNABLE_CODES = Set([91, 92, 93, 98, 99])
+
 # Build lookup tables from ANDERSON_FUEL_DATA once at module load time.
 const _FUEL_SAVR = let
     d = Dict{Int, Float64}()
@@ -79,6 +82,9 @@ const _FUEL_HEAT = let
         # ANDERSON_FUEL_DATA.h is in BTU/lb; convert to J/kg
         d[k] = v.h * 2326.0
     end
+    for code in _NONBURNABLE_CODES
+        d[code] = 0.0
+    end
     d
 end
 
@@ -92,7 +98,7 @@ fuel_savr(code) = _lookup_fuel(_FUEL_SAVR, code, 3500.0 / 0.3048)
 fuel_load(code) = _lookup_fuel(_FUEL_LOAD, code, 0.166)
 fuel_depth(code) = _lookup_fuel(_FUEL_DEPTH, code, 0.305)
 fuel_mce(code) = _lookup_fuel(_FUEL_MCE, code, 0.12)
-fuel_heat(code) = _lookup_fuel(_FUEL_HEAT, code, 8000.0 * 2326.0)
+fuel_heat(code) = _lookup_fuel(_FUEL_HEAT, code, 0.0)
 
 # Register for use in symbolic equations.
 @register_symbolic fuel_savr(code)
@@ -118,6 +124,11 @@ parameters using the Anderson 13 fuel model data.
 
 Takes `fuel_model` as input (dimensionless integer code from LANDFIRE) and
 outputs the five core Rothermel parameters: `σ`, `w0`, `δ`, `Mx`, `h`.
+
+Non-burnable LANDFIRE codes (91=urban, 92=snow/ice, 93=agriculture, 98=water,
+99=barren) and unrecognized codes return zero heat content (`h=0`), which
+guarantees the Rothermel model computes zero reaction intensity (`IR=0`) and
+therefore zero rate of spread (`R=0`).
 """
 @component function FuelModelLookup(; name = :FuelModelLookup)
     @constants begin

--- a/test/coupling_test.jl
+++ b/test/coupling_test.jl
@@ -44,8 +44,31 @@ end
     @test WildlandFire.fuel_load(1.0) ≈ 0.166  rtol = 0.01
     @test WildlandFire.fuel_depth(1.0) ≈ 0.305  rtol = 0.01
     @test WildlandFire.fuel_mce(1.0) ≈ 0.12  rtol = 0.01
-    # Non-burnable code should return default
+    # Non-burnable code 98 (water): SAVR stays at FM1 default to avoid division by zero
     @test WildlandFire.fuel_savr(98.0) ≈ 3500.0 / 0.3048  rtol = 0.01
+    # Heat content should be zero for non-burnable codes
+    @test WildlandFire.fuel_heat(98.0) == 0.0
+end
+
+@testitem "Non-burnable fuel lookup" setup = [CouplingSetup] tags = [:coupling] begin
+    # All standard non-burnable LANDFIRE FBFM13 codes
+    for code in [91.0, 92.0, 93.0, 98.0, 99.0]
+        # Heat content must be zero to ensure IR=0 and therefore R=0
+        @test WildlandFire.fuel_heat(code) == 0.0
+        # SAVR, depth, load, and Mx must remain positive to avoid division by zero in Rothermel
+        @test WildlandFire.fuel_savr(code) > 0.0
+        @test WildlandFire.fuel_depth(code) > 0.0
+        @test WildlandFire.fuel_load(code) > 0.0
+        @test WildlandFire.fuel_mce(code) > 0.0
+    end
+
+    # Unrecognized codes should also return zero heat content
+    @test WildlandFire.fuel_heat(0.0) == 0.0
+    @test WildlandFire.fuel_heat(999.0) == 0.0
+
+    # Valid fuel models (1-13) should still return nonzero heat
+    @test WildlandFire.fuel_heat(1.0) > 0.0
+    @test WildlandFire.fuel_heat(13.0) > 0.0
 end
 
 @testitem "RothermelFireSpread has CoupleType" setup = [CouplingSetup] tags = [:coupling] begin

--- a/test/test_rothermel.jl
+++ b/test/test_rothermel.jl
@@ -619,3 +619,29 @@ end
     @test R_US > 0.5   # Minimum reasonable spread rate
     @test R_US < 20.0  # Maximum reasonable spread rate for short grass without wind
 end
+
+@testitem "Non-burnable fuel yields R=0" setup = [RothermelSetup] tags = [:rothermel] begin
+    # Non-burnable codes return h=0 while keeping other parameters at FM1 defaults.
+    # With h=0, IR = Γ' * wn * h * η_M * η_s = 0, so R0 = 0/(positive) = 0 and R = 0.
+    sys = RothermelFireSpread()
+    compiled_sys = mtkcompile(sys)
+
+    prob = NonlinearProblem(
+        compiled_sys, Dict(
+            compiled_sys.σ => σ_SI,            # FM1 default (keeps denominators safe)
+            compiled_sys.w0 => w0_SI,          # FM1 default (keeps ρb > 0)
+            compiled_sys.δ => δ_SI,            # FM1 default (keeps ρb denominator safe)
+            compiled_sys.Mx => 0.12,           # FM1 default (keeps rM denominator safe)
+            compiled_sys.Mf => 0.05,
+            compiled_sys.U => 2.235,           # Nonzero wind to test that R is still zero
+            compiled_sys.tanϕ => 0.3,          # Nonzero slope to test that R is still zero
+            compiled_sys.h => 0.0,             # Non-burnable: zero heat content
+        )
+    )
+
+    sol = solve(prob)
+
+    @test sol[compiled_sys.IR] == 0.0   # No reaction intensity
+    @test sol[compiled_sys.R0] == 0.0   # No base spread rate
+    @test sol[compiled_sys.R] == 0.0    # No spread rate even with wind and slope
+end


### PR DESCRIPTION
## Summary

- Non-burnable LANDFIRE codes (91=urban, 92=snow/ice, 93=agriculture, 98=water, 99=barren) previously returned fuel model 1 (short grass) properties, causing fire to spread through water, cities, and bare rock
- Set heat content (`h`) to zero for non-burnable and unrecognized codes, which guarantees `IR=0` and therefore `R=0` in the Rothermel model
- Other fuel parameters (σ, w0, δ, Mx) remain at FM1 defaults to keep all Rothermel denominators positive and avoid NaN/division-by-zero

Closes #40

## Test plan

- [x] New `@testitem "Non-burnable fuel lookup"` verifies all 5 non-burnable codes return `h=0` and other params stay positive
- [x] New `@testitem "Non-burnable fuel yields R=0"` verifies Rothermel computes `IR=0`, `R0=0`, `R=0` with `h=0` (even with nonzero wind and slope)
- [x] Updated existing `"Fuel lookup functions"` test to check `fuel_heat(98.0) == 0.0`
- [x] All 127 Rothermel tests pass
- [x] All 124 coupling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)