### PR TITLE
Fix FireSpreadDirection U_ref to match Rothermel model

### DIFF
--- a/src/fire_spread_direction.jl
+++ b/src/fire_spread_direction.jl
@@ -63,7 +63,7 @@ sol = solve(prob)
         # Z = 1 + 0.25*U_E where U_E is in mi/h
         # Since 1 m/s = 2.23694 mi/h: Z = 1 + 0.25 * 2.23694 * U_E = 1 + 0.559 * U_E (U_E in m/s)
         c_Z = 0.559235, [description = "Length-to-width ratio coefficient (SI)", unit = u"s/m"]
-        U_ref = 1.0, [description = "Reference wind speed", unit = u"m/s"]
+        U_ref = 0.3048 / 60, [description = "Reference wind speed (1 ft/min in m/s)", unit = u"m/s"]
         φ_min = 1.0e-10, [description = "Minimum combined factor to avoid division by zero (dimensionless)", unit = u"1"]
     end
 

--- a/test/test_fire_spread_direction.jl
+++ b/test/test_fire_spread_direction.jl
@@ -160,6 +160,48 @@ end
     @test ustrip(sol[compiled_sys.U_E]) ≥ 0.0
 end
 
+@testitem "FireSpreadDirection - Realistic U_E and Z values" setup = [FireSpreadDirectionSetup] tags = [:fire_spread_direction] begin
+    # Regression test for issue #50: U_ref must be 0.3048/60 m/s (1 ft/min)
+    # With typical fire conditions, U_E and Z should be physically realistic.
+    # Before the fix, U_E was ~197x too large and Z was ~496 instead of ~3.5.
+
+    sys = FireSpreadDirection()
+    compiled_sys = mtkcompile(sys)
+
+    # Typical conditions: moderate wind factor, no slope, wind aligned upslope
+    prob = NonlinearProblem(
+        compiled_sys, Dict(
+            compiled_sys.R0 => 0.01,
+            compiled_sys.φw => 5.0,
+            compiled_sys.φs => 0.0,
+            compiled_sys.ω => 0.0,
+            compiled_sys.β_ratio => 0.5,
+            compiled_sys.C_coeff => 7.47,
+            compiled_sys.B_coeff => 0.15566,
+            compiled_sys.E_coeff => 0.715,
+        )
+    )
+    sol = solve(prob)
+
+    U_E_val = ustrip(sol[compiled_sys.U_E])
+    Z_val = ustrip(sol[compiled_sys.Z])
+
+    # U_E should be on the order of a few m/s, not hundreds
+    @test U_E_val < 50.0  # m/s; before fix this was ~885 m/s
+    @test U_E_val > 0.0
+
+    # Z should be a reasonable fire length-to-width ratio (typically 1-10)
+    @test Z_val < 30.0  # before fix this was ~496
+    @test Z_val > 1.0
+
+    # Verify U_E is consistent with the Rothermel model's U_ref = 0.3048/60
+    # U_E = U_ref * (φ_E * β_ratio^E / C)^(1/B)
+    U_ref = 0.3048 / 60  # must match the implementation
+    φ_E_val = ustrip(sol[compiled_sys.φ_E])
+    expected_U_E = U_ref * (φ_E_val * 0.5^0.715 / 7.47)^(1.0 / 0.15566)
+    @test U_E_val ≈ expected_U_E rtol = 1.0e-6
+end
+
 # ==============================================================================
 # EllipticalFireSpread Tests
 # ==============================================================================


### PR DESCRIPTION
## Summary

- Fix `U_ref` in `FireSpreadDirection` from `1.0 m/s` to `0.3048/60 m/s` (1 ft/min) to match the Rothermel model's unit system used in `RothermelFireSpread` and `EffectiveMidflameWindSpeed`
- Add regression test verifying `U_E` and `Z` produce physically realistic values

## Details

The effective wind speed equation inverts Rothermel's wind factor `φw = C * (U / U_ref)^B * β_ratio^(-E)`, so `U_ref` must be the same value (0.3048/60 m/s = 1 ft/min) used in the original formulation. The incorrect `U_ref = 1.0` made `U_E` ~197x too large, producing unrealistic fire length-to-width ratios (~496 instead of ~3.5).

Head fire rate of spread `R_H` was **not** affected — only `U_E`, `Z`, and downstream elliptical fire shape calculations.

Fixes #50

## Test plan

- [x] All 84 existing tests pass (including the new regression test)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)